### PR TITLE
scan metrics procedure

### DIFF
--- a/api/src/main/java/org/apache/iceberg/RewriteJobOrder.java
+++ b/api/src/main/java/org/apache/iceberg/RewriteJobOrder.java
@@ -43,6 +43,7 @@ public enum RewriteJobOrder {
   FILES_ASC("files-asc"),
   FILES_DESC("files-desc"),
   DELETES_DESC("deletes-desc"),
+  AFFECTED_EQ_DELETE_ROWS_DESC("affected-eq-delete-rows-desc"),
   NONE("none");
 
   private final String orderName;
@@ -60,7 +61,7 @@ public enum RewriteJobOrder {
     // Replace the hyphen in order name with underscore to map to the enum value. For example:
     // bytes-asc to BYTES_ASC
     try {
-      return RewriteJobOrder.valueOf(orderName.replaceFirst("-", "_").toUpperCase(Locale.ENGLISH));
+      return RewriteJobOrder.valueOf(orderName.replaceAll("-", "_").toUpperCase(Locale.ENGLISH));
     } catch (IllegalArgumentException e) {
       throw new IllegalArgumentException(
           String.format("Invalid rewrite job order name: %s", orderName), e);

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/procedures/ScanMetricsProcedure.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/procedures/ScanMetricsProcedure.java
@@ -1,0 +1,163 @@
+package org.apache.iceberg.spark.procedures;
+
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicLong;
+import org.apache.iceberg.DataFile;
+import org.apache.iceberg.DeleteFile;
+import org.apache.iceberg.FileContent;
+import org.apache.iceberg.FileScanTask;
+import org.apache.iceberg.TableScan;
+import org.apache.iceberg.io.CloseableIterable;
+import org.apache.iceberg.relocated.com.google.common.collect.Sets;
+import org.apache.spark.sql.catalyst.InternalRow;
+import org.apache.spark.sql.catalyst.expressions.GenericInternalRow;
+import org.apache.spark.sql.connector.catalog.Identifier;
+import org.apache.spark.sql.connector.catalog.TableCatalog;
+import org.apache.spark.sql.connector.iceberg.catalog.ProcedureParameter;
+import org.apache.spark.sql.types.DataTypes;
+import org.apache.spark.sql.types.Metadata;
+import org.apache.spark.sql.types.StructField;
+import org.apache.spark.sql.types.StructType;
+
+public class ScanMetricsProcedure extends BaseProcedure {
+
+    private static final ProcedureParameter TABLE_PARAM =
+            ProcedureParameter.required("table", DataTypes.StringType);
+    private static final ProcedureParameter SNAPSHOT_ID_PARAM =
+            ProcedureParameter.optional("snapshot_id", DataTypes.LongType);
+
+    private static final ProcedureParameter[] PARAMETERS =
+            new ProcedureParameter[]{TABLE_PARAM, SNAPSHOT_ID_PARAM};
+
+    private static final StructType OUTPUT_TYPE = new StructType(
+            new StructField[]{
+                    new StructField("total_data_records", DataTypes.LongType, false, Metadata.empty()),
+                    new StructField("total_data_files", DataTypes.LongType, false, Metadata.empty()),
+                    new StructField("records_with_no_deletes", DataTypes.LongType, false, Metadata.empty()),
+                    new StructField("records_with_only_eq_deletes", DataTypes.LongType, false, Metadata.empty()),
+                    new StructField("records_with_only_pos_deletes", DataTypes.LongType, false, Metadata.empty()),
+                    new StructField("records_with_both_deletes", DataTypes.LongType, false, Metadata.empty()),
+                    new StructField("records_with_eq_deletes_total", DataTypes.LongType, false, Metadata.empty()),
+                    new StructField("unique_eq_delete_files", DataTypes.IntegerType, false, Metadata.empty()),
+                    new StructField("eq_delete_files_referenced", DataTypes.LongType, false, Metadata.empty()),
+                    new StructField("eq_delete_records", DataTypes.LongType, false, Metadata.empty()),
+                    new StructField("unique_pos_delete_files", DataTypes.IntegerType, false, Metadata.empty()),
+                    new StructField("pos_delete_files_referenced", DataTypes.LongType, false, Metadata.empty()),
+                    new StructField("pos_delete_records", DataTypes.LongType, false, Metadata.empty())
+            });
+
+    public static Builder<ScanMetricsProcedure> builder() {
+        return new Builder<ScanMetricsProcedure>() {
+            @Override
+            protected ScanMetricsProcedure doBuild() {
+                return new ScanMetricsProcedure(tableCatalog());
+            }
+        };
+    }
+
+    private ScanMetricsProcedure(TableCatalog catalog) {
+        super(catalog);
+    }
+
+    @Override
+    public ProcedureParameter[] parameters() {
+        return PARAMETERS;
+    }
+
+    @Override
+    public StructType outputType() {
+        return OUTPUT_TYPE;
+    }
+
+    @Override
+    public String description() {
+        return "Collects metrics about data files and their associated delete files";
+    }
+
+    @Override
+    public InternalRow[] call(InternalRow args) {
+        ProcedureInput input = new ProcedureInput(spark(), tableCatalog(), PARAMETERS, args);
+        Identifier ident = input.ident(TABLE_PARAM);
+        Long snapshotId = input.asLong(SNAPSHOT_ID_PARAM, null);
+
+        return withIcebergTable(ident, icebergTable -> {
+            TableScan scan = icebergTable.newScan();
+            if (snapshotId != null) {
+                scan = scan.useSnapshot(snapshotId);
+            }
+
+            CloseableIterable<FileScanTask> tasks = scan.planFiles();
+
+            AtomicLong totalDataRecords = new AtomicLong(0);
+            AtomicLong dataRecordsWithNoDeletes = new AtomicLong(0);
+            AtomicLong dataRecordsWithOnlyEqDeletes = new AtomicLong(0);
+            AtomicLong dataRecordsWithOnlyPosDeletes = new AtomicLong(0);
+            AtomicLong dataRecordsWithBothDeletes = new AtomicLong(0);
+            Set<String> uniqEqDeleteFiles = Sets.newHashSet();
+            Set<String> uniqPosDeleteFiles = Sets.newHashSet();
+            AtomicLong totalEqDeleteRecords = new AtomicLong(0);
+            AtomicLong totalPosDeleteRecords = new AtomicLong(0);
+            AtomicLong eqDeleteFilesReferenced = new AtomicLong(0);
+            AtomicLong posDeleteFilesReferenced = new AtomicLong(0);
+            AtomicLong totalDataFiles = new AtomicLong(0);
+
+            for (FileScanTask task : tasks) {
+                DataFile dataFile = task.file();
+                List<DeleteFile> deleteFiles = task.deletes();
+                totalDataFiles.incrementAndGet();
+
+                long eqDeleteFileCount = 0;
+                long posDeleteFileCount = 0;
+
+                for (DeleteFile deleteFile : deleteFiles) {
+                    if (deleteFile.content() == FileContent.EQUALITY_DELETES) {
+                        eqDeleteFileCount++;
+                        eqDeleteFilesReferenced.incrementAndGet();
+                        if (uniqEqDeleteFiles.add(deleteFile.path().toString())) {
+                            totalEqDeleteRecords.addAndGet(deleteFile.recordCount());
+                        }
+                    } else if (deleteFile.content() == FileContent.POSITION_DELETES) {
+                        posDeleteFileCount++;
+                        posDeleteFilesReferenced.incrementAndGet();
+                        if (uniqPosDeleteFiles.add(deleteFile.path().toString())) {
+                            totalPosDeleteRecords.addAndGet(deleteFile.recordCount());
+                        }
+                    }
+                }
+
+                long dataRecordCount = dataFile.recordCount();
+                totalDataRecords.addAndGet(dataRecordCount);
+
+                if (eqDeleteFileCount == 0 && posDeleteFileCount == 0) {
+                    dataRecordsWithNoDeletes.addAndGet(dataRecordCount);
+                } else if (eqDeleteFileCount > 0 && posDeleteFileCount == 0) {
+                    dataRecordsWithOnlyEqDeletes.addAndGet(dataRecordCount);
+                } else if (eqDeleteFileCount == 0 && posDeleteFileCount > 0) {
+                    dataRecordsWithOnlyPosDeletes.addAndGet(dataRecordCount);
+                } else {
+                    dataRecordsWithBothDeletes.addAndGet(dataRecordCount);
+                }
+            }
+
+            long dataRecordsWithEqDeletesTotal =
+                    dataRecordsWithOnlyEqDeletes.get() + dataRecordsWithBothDeletes.get();
+
+            return new InternalRow[]{new GenericInternalRow(new Object[]{
+                    totalDataRecords.get(),
+                    totalDataFiles.get(),
+                    dataRecordsWithNoDeletes.get(),
+                    dataRecordsWithOnlyEqDeletes.get(),
+                    dataRecordsWithOnlyPosDeletes.get(),
+                    dataRecordsWithBothDeletes.get(),
+                    dataRecordsWithEqDeletesTotal,
+                    uniqEqDeleteFiles.size(),
+                    eqDeleteFilesReferenced.get(),
+                    totalEqDeleteRecords.get(),
+                    uniqPosDeleteFiles.size(),
+                    posDeleteFilesReferenced.get(),
+                    totalPosDeleteRecords.get()
+            })};
+        });
+    }
+}

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/procedures/SparkProcedures.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/procedures/SparkProcedures.java
@@ -56,6 +56,8 @@ public class SparkProcedures {
     mapBuilder.put("create_changelog_view", CreateChangelogViewProcedure::builder);
     mapBuilder.put("rewrite_position_delete_files", RewritePositionDeleteFilesProcedure::builder);
     mapBuilder.put("fast_forward", FastForwardBranchProcedure::builder);
+    mapBuilder.put("scan_metrics", ScanMetricsProcedure::builder);
+
     return mapBuilder.build();
   }
 


### PR DESCRIPTION
spark-sql ()> SET spark.sql.cli.print.header=true;
key	value
spark.sql.cli.print.header	true
Time taken: 0.783 seconds, Fetched 1 row(s)

spark-sql ()> call my_catalog.system.scan_metrics('landing_cbs_tj.transactions');
total_data_records	total_data_files	records_with_no_deletes	records_with_only_eq_deletes	records_with_only_pos_deletes	records_with_both_deletes	records_with_eq_deletes_total	unique_eq_delete_files	eq_delete_files_referenced	eq_delete_records	unique_pos_delete_files	pos_delete_files_referenced	pos_delete_records
617929135	9207	604264880	10410358	204938	3048959	13459317	68	239	726	14	47	73
Time taken: 3.958 seconds, Fetched 1 row(s)